### PR TITLE
feat: add optional compressor to stage final output

### DIFF
--- a/debug-ui/app/wasm-test.tsx
+++ b/debug-ui/app/wasm-test.tsx
@@ -422,6 +422,39 @@ export default function WasmTest() {
     }
   }
 
+  function handleCompressorEnabledChange(enabled: boolean) {
+    if (!stageRef.current) return;
+    
+    stageRef.current.set_compressor_enabled(enabled);
+    setCompressorEnabled(enabled);
+  }
+
+  function handleCompressorConfigChange(param: keyof typeof compressorConfig, value: number) {
+    if (!stageRef.current) return;
+    
+    // Update local state
+    setCompressorConfig(prev => ({ ...prev, [param]: value }));
+    
+    // Update the stage compressor
+    switch (param) {
+      case 'threshold':
+        stageRef.current.set_compressor_threshold(value);
+        break;
+      case 'ratio':
+        stageRef.current.set_compressor_ratio(value);
+        break;
+      case 'attack':
+        stageRef.current.set_compressor_attack(value);
+        break;
+      case 'release':
+        stageRef.current.set_compressor_release(value);
+        break;
+      case 'makeupGain':
+        stageRef.current.set_compressor_makeup_gain(value);
+        break;
+    }
+  }
+
   return (
     <div className="p-8 max-w-lg mx-auto">
       <h1 className="text-2xl font-bold mb-6">WASM Audio Engine Test</h1>
@@ -686,6 +719,119 @@ export default function WasmTest() {
             Release All Instruments
           </button>
 
+          {/* Compressor Section */}
+          <div className="mt-8 pt-6 border-t border-gray-600">
+            <h3 className="font-semibold mb-4 text-center text-lg">🎛️ Compressor</h3>
+            
+            {/* Compressor Enable/Disable */}
+            <div className="flex items-center justify-center mb-4">
+              <button
+                onClick={() => handleCompressorEnabledChange(!compressorEnabled)}
+                disabled={!isLoaded}
+                className={`px-6 py-2 font-medium rounded-lg transition-colors disabled:cursor-not-allowed ${
+                  compressorEnabled
+                    ? 'bg-green-600 text-white hover:bg-green-700 disabled:bg-gray-600'
+                    : 'bg-red-600 text-white hover:bg-red-700 disabled:bg-gray-600'
+                }`}
+              >
+                {compressorEnabled ? '🎛️ COMPRESSOR ON' : '🔇 COMPRESSOR OFF'}
+              </button>
+            </div>
+
+            {/* Compressor Controls */}
+            <div className="space-y-3">
+              {/* Threshold */}
+              <div className="flex items-center space-x-2">
+                <label className="w-20 text-sm font-medium">Threshold</label>
+                <input
+                  type="range"
+                  min="-40"
+                  max="0"
+                  step="0.5"
+                  value={compressorConfig.threshold}
+                  onChange={(e) => handleCompressorConfigChange('threshold', parseFloat(e.target.value))}
+                  disabled={!isLoaded}
+                  className="flex-1 h-2 bg-gray-200 rounded-lg appearance-none cursor-pointer disabled:cursor-not-allowed"
+                />
+                <span className="w-12 text-sm font-mono text-right">
+                  {compressorConfig.threshold.toFixed(1)}dB
+                </span>
+              </div>
+
+              {/* Ratio */}
+              <div className="flex items-center space-x-2">
+                <label className="w-20 text-sm font-medium">Ratio</label>
+                <input
+                  type="range"
+                  min="1"
+                  max="20"
+                  step="0.1"
+                  value={compressorConfig.ratio}
+                  onChange={(e) => handleCompressorConfigChange('ratio', parseFloat(e.target.value))}
+                  disabled={!isLoaded}
+                  className="flex-1 h-2 bg-gray-200 rounded-lg appearance-none cursor-pointer disabled:cursor-not-allowed"
+                />
+                <span className="w-12 text-sm font-mono text-right">
+                  {compressorConfig.ratio.toFixed(1)}:1
+                </span>
+              </div>
+
+              {/* Attack */}
+              <div className="flex items-center space-x-2">
+                <label className="w-20 text-sm font-medium">Attack</label>
+                <input
+                  type="range"
+                  min="1"
+                  max="100"
+                  step="0.1"
+                  value={compressorConfig.attack}
+                  onChange={(e) => handleCompressorConfigChange('attack', parseFloat(e.target.value))}
+                  disabled={!isLoaded}
+                  className="flex-1 h-2 bg-gray-200 rounded-lg appearance-none cursor-pointer disabled:cursor-not-allowed"
+                />
+                <span className="w-12 text-sm font-mono text-right">
+                  {compressorConfig.attack.toFixed(1)}ms
+                </span>
+              </div>
+
+              {/* Release */}
+              <div className="flex items-center space-x-2">
+                <label className="w-20 text-sm font-medium">Release</label>
+                <input
+                  type="range"
+                  min="10"
+                  max="1000"
+                  step="1"
+                  value={compressorConfig.release}
+                  onChange={(e) => handleCompressorConfigChange('release', parseFloat(e.target.value))}
+                  disabled={!isLoaded}
+                  className="flex-1 h-2 bg-gray-200 rounded-lg appearance-none cursor-pointer disabled:cursor-not-allowed"
+                />
+                <span className="w-12 text-sm font-mono text-right">
+                  {compressorConfig.release.toFixed(0)}ms
+                </span>
+              </div>
+
+              {/* Makeup Gain */}
+              <div className="flex items-center space-x-2">
+                <label className="w-20 text-sm font-medium">Makeup</label>
+                <input
+                  type="range"
+                  min="-20"
+                  max="20"
+                  step="0.1"
+                  value={compressorConfig.makeupGain}
+                  onChange={(e) => handleCompressorConfigChange('makeupGain', parseFloat(e.target.value))}
+                  disabled={!isLoaded}
+                  className="flex-1 h-2 bg-gray-200 rounded-lg appearance-none cursor-pointer disabled:cursor-not-allowed"
+                />
+                <span className="w-12 text-sm font-mono text-right">
+                  {compressorConfig.makeupGain.toFixed(1)}dB
+                </span>
+              </div>
+            </div>
+          </div>
+
           {/* Kick Drum Section */}
           <div className="mt-8 pt-6 border-t border-gray-600">
             <h3 className="font-semibold mb-4 text-center text-lg">🥁 Kick Drum</h3>
@@ -859,6 +1005,7 @@ export default function WasmTest() {
       <div className="mt-6 p-4 bg-gray-800 rounded">
         <h2 className="font-semibold mb-2">Status:</h2>
         <p>WASM Stage: {isLoaded ? '✅ Loaded (4 oscillators)' : '❌ Not loaded'}</p>
+        <p>Compressor: {isLoaded ? (compressorEnabled ? '✅ Enabled' : '⚪ Disabled') : '❌ Not loaded'}</p>
         <p>Kick Drum: {isLoaded && kickDrumRef.current ? '✅ Loaded' : '❌ Not loaded'}</p>
         <p>Audio Context: {audioContextRef.current ? '✅ Ready' : '❌ No'}</p>
         <p>Audio Playing: {isPlaying ? '✅ Yes' : '❌ No'}</p>
@@ -880,7 +1027,8 @@ export default function WasmTest() {
           <li>• <strong>Kick Drum Instrument</strong>: Comprehensive 3-layer kick drum with sub-bass, punch, and click layers</li>
           <li>• <strong>Kick Presets</strong>: Built-in presets (Default, Punchy, Deep, Tight) for different kick styles</li>
           <li>• <strong>Kick Parameters</strong>: Frequency, punch, sub-bass, click, decay time, and pitch drop controls</li>
-          <li>• <strong>Audio mixing</strong>: Stage.tick() sums all instrument outputs with controls applied</li>
+          <li>• <strong>Optional Compressor</strong>: Enable/disable compressor with threshold, ratio, attack, release, and makeup gain controls</li>
+          <li>• <strong>Audio Processing Chain</strong>: Instruments → Sum → Compressor (optional) → Limiter → Output</li>
         </ul>
       </div>
 
@@ -917,6 +1065,15 @@ export default function WasmTest() {
             <li><strong>Click:</strong> Control high-frequency transient</li>
             <li><strong>Decay:</strong> Adjust overall decay time</li>
             <li><strong>Pitch Drop:</strong> Control frequency sweep effect</li>
+          </ul>
+          <li>Experiment with the optional compressor for dynamic range control:</li>
+          <ul className="list-disc list-inside ml-4 text-xs space-y-0.5 text-yellow-200">
+            <li><strong>Enable/Disable:</strong> Toggle compressor on/off to hear the difference</li>
+            <li><strong>Threshold:</strong> Level above which compression starts (-40dB to 0dB)</li>
+            <li><strong>Ratio:</strong> Amount of compression applied above threshold (1:1 to 20:1)</li>
+            <li><strong>Attack:</strong> How quickly compression engages (1ms to 100ms)</li>
+            <li><strong>Release:</strong> How quickly compression disengages (10ms to 1000ms)</li>
+            <li><strong>Makeup Gain:</strong> Compensate for level reduction (-20dB to +20dB)</li>
           </ul>
         </ol>
       </div>

--- a/lib/src/compressor.rs
+++ b/lib/src/compressor.rs
@@ -1,0 +1,94 @@
+/// A compressor that applies dynamic range compression to audio signals
+pub struct Compressor {
+    pub enabled: bool,
+    pub threshold: f32,           // dB
+    pub ratio: f32,               // compression ratio (e.g., 4.0 = 4:1)
+    pub attack_coeff: f32,        // attack time coefficient
+    pub release_coeff: f32,       // release time coefficient
+    pub makeup_gain_db: f32,      // makeup gain in dB
+    envelope_follower: f32,       // current envelope level
+    sample_rate: f32,             // for calculating time constants
+}
+
+impl Compressor {
+    pub fn new(sample_rate: f32) -> Self {
+        let mut compressor = Self {
+            enabled: false,
+            threshold: -12.0,    // -12dB threshold
+            ratio: 4.0,          // 4:1 ratio
+            attack_coeff: 0.0,
+            release_coeff: 0.0,
+            makeup_gain_db: 0.0, // 0dB makeup gain
+            envelope_follower: 0.0,
+            sample_rate,
+        };
+        compressor.set_attack(3.0);   // 3ms attack
+        compressor.set_release(100.0); // 100ms release
+        compressor
+    }
+
+    pub fn set_attack(&mut self, attack_ms: f32) {
+        // Convert milliseconds to time constant coefficient
+        let attack_seconds = attack_ms / 1000.0;
+        self.attack_coeff = (-1.0 / (attack_seconds * self.sample_rate)).exp();
+    }
+
+    pub fn get_attack(&self) -> f32 {
+        // Convert back to milliseconds
+        if self.attack_coeff == 0.0 {
+            return 0.001;
+        }
+        -1000.0 / (self.attack_coeff.ln() * self.sample_rate)
+    }
+
+    pub fn set_release(&mut self, release_ms: f32) {
+        // Convert milliseconds to time constant coefficient
+        let release_seconds = release_ms / 1000.0;
+        self.release_coeff = (-1.0 / (release_seconds * self.sample_rate)).exp();
+    }
+
+    pub fn get_release(&self) -> f32 {
+        // Convert back to milliseconds
+        if self.release_coeff == 0.0 {
+            return 10.0;
+        }
+        -1000.0 / (self.release_coeff.ln() * self.sample_rate)
+    }
+
+    pub fn process(&mut self, input: f32) -> f32 {
+        if !self.enabled {
+            return input;
+        }
+
+        // Convert input to dB
+        let input_db = if input.abs() > 0.000001 {
+            20.0 * input.abs().log10()
+        } else {
+            -120.0 // Very quiet signal
+        };
+
+        // Envelope follower
+        let target_level = input_db;
+        if target_level > self.envelope_follower {
+            // Attack
+            self.envelope_follower = target_level + (self.envelope_follower - target_level) * self.attack_coeff;
+        } else {
+            // Release
+            self.envelope_follower = target_level + (self.envelope_follower - target_level) * self.release_coeff;
+        }
+
+        // Calculate gain reduction
+        let gain_reduction_db = if self.envelope_follower > self.threshold {
+            let over_threshold = self.envelope_follower - self.threshold;
+            over_threshold * (1.0 - 1.0 / self.ratio)
+        } else {
+            0.0
+        };
+
+        // Apply makeup gain and gain reduction
+        let total_gain_db = self.makeup_gain_db - gain_reduction_db;
+        let gain_linear = (total_gain_db * 0.05 * std::f32::consts::LN_10).exp(); // Convert dB to linear
+
+        input * gain_linear
+    }
+}

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -185,6 +185,67 @@ pub mod web {
         pub fn is_instrument_enabled(&self, index: usize) -> bool {
             self.stage.is_instrument_enabled(index)
         }
+
+        // Compressor control methods
+        #[wasm_bindgen]
+        pub fn set_compressor_enabled(&mut self, enabled: bool) {
+            self.stage.set_compressor_enabled(enabled);
+        }
+
+        #[wasm_bindgen]
+        pub fn is_compressor_enabled(&self) -> bool {
+            self.stage.is_compressor_enabled()
+        }
+
+        #[wasm_bindgen]
+        pub fn set_compressor_threshold(&mut self, threshold: f32) {
+            self.stage.set_compressor_threshold(threshold);
+        }
+
+        #[wasm_bindgen]
+        pub fn get_compressor_threshold(&self) -> f32 {
+            self.stage.get_compressor_threshold()
+        }
+
+        #[wasm_bindgen]
+        pub fn set_compressor_ratio(&mut self, ratio: f32) {
+            self.stage.set_compressor_ratio(ratio);
+        }
+
+        #[wasm_bindgen]
+        pub fn get_compressor_ratio(&self) -> f32 {
+            self.stage.get_compressor_ratio()
+        }
+
+        #[wasm_bindgen]
+        pub fn set_compressor_attack(&mut self, attack_ms: f32) {
+            self.stage.set_compressor_attack(attack_ms);
+        }
+
+        #[wasm_bindgen]
+        pub fn get_compressor_attack(&self) -> f32 {
+            self.stage.get_compressor_attack()
+        }
+
+        #[wasm_bindgen]
+        pub fn set_compressor_release(&mut self, release_ms: f32) {
+            self.stage.set_compressor_release(release_ms);
+        }
+
+        #[wasm_bindgen]
+        pub fn get_compressor_release(&self) -> f32 {
+            self.stage.get_compressor_release()
+        }
+
+        #[wasm_bindgen]
+        pub fn set_compressor_makeup_gain(&mut self, gain_db: f32) {
+            self.stage.set_compressor_makeup_gain(gain_db);
+        }
+
+        #[wasm_bindgen]
+        pub fn get_compressor_makeup_gain(&self) -> f32 {
+            self.stage.get_compressor_makeup_gain()
+        }
     }
 
     #[wasm_bindgen]

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -1,6 +1,7 @@
 //! Shared audio engine logic for both native (CPAL) and WASM (web)
 
 pub mod audio_state;
+pub mod compressor;
 pub mod envelope;
 pub mod kick;
 pub mod oscillator;

--- a/lib/src/stage.rs
+++ b/lib/src/stage.rs
@@ -4,6 +4,7 @@ use crate::oscillator::Oscillator;
 pub struct Stage {
     pub sample_rate: f32,
     pub instruments: Vec<Oscillator>,
+    pub compressor: Compressor,
     pub limiter: BrickWallLimiter,
 }
 
@@ -12,6 +13,7 @@ impl Stage {
         Self {
             sample_rate,
             instruments: Vec::new(),
+            compressor: Compressor::new(sample_rate),
             limiter: BrickWallLimiter::new(1.0), // Default threshold at 1.0 to prevent clipping
         }
     }
@@ -27,6 +29,8 @@ impl Stage {
         for instrument in &mut self.instruments {
             output += instrument.tick(current_time);
         }
+        // Apply compressor before limiter if enabled
+        output = self.compressor.process(output);
         // Apply limiter to the combined output
         self.limiter.process(output)
     }
@@ -139,6 +143,150 @@ impl Stage {
     /// Get the current limiter threshold
     pub fn get_limiter_threshold(&self) -> f32 {
         self.limiter.threshold
+    }
+
+    // Compressor control methods
+    pub fn set_compressor_enabled(&mut self, enabled: bool) {
+        self.compressor.enabled = enabled;
+    }
+
+    pub fn is_compressor_enabled(&self) -> bool {
+        self.compressor.enabled
+    }
+
+    pub fn set_compressor_threshold(&mut self, threshold: f32) {
+        self.compressor.threshold = threshold;
+    }
+
+    pub fn get_compressor_threshold(&self) -> f32 {
+        self.compressor.threshold
+    }
+
+    pub fn set_compressor_ratio(&mut self, ratio: f32) {
+        self.compressor.ratio = ratio;
+    }
+
+    pub fn get_compressor_ratio(&self) -> f32 {
+        self.compressor.ratio
+    }
+
+    pub fn set_compressor_attack(&mut self, attack_ms: f32) {
+        self.compressor.set_attack(attack_ms);
+    }
+
+    pub fn get_compressor_attack(&self) -> f32 {
+        self.compressor.get_attack()
+    }
+
+    pub fn set_compressor_release(&mut self, release_ms: f32) {
+        self.compressor.set_release(release_ms);
+    }
+
+    pub fn get_compressor_release(&self) -> f32 {
+        self.compressor.get_release()
+    }
+
+    pub fn set_compressor_makeup_gain(&mut self, gain_db: f32) {
+        self.compressor.makeup_gain_db = gain_db;
+    }
+
+    pub fn get_compressor_makeup_gain(&self) -> f32 {
+        self.compressor.makeup_gain_db
+    }
+}
+
+/// A compressor that applies dynamic range compression to audio signals
+pub struct Compressor {
+    pub enabled: bool,
+    pub threshold: f32,           // dB
+    pub ratio: f32,               // compression ratio (e.g., 4.0 = 4:1)
+    pub attack_coeff: f32,        // attack time coefficient
+    pub release_coeff: f32,       // release time coefficient
+    pub makeup_gain_db: f32,      // makeup gain in dB
+    envelope_follower: f32,       // current envelope level
+    sample_rate: f32,             // for calculating time constants
+}
+
+impl Compressor {
+    pub fn new(sample_rate: f32) -> Self {
+        let mut compressor = Self {
+            enabled: false,
+            threshold: -12.0,    // -12dB threshold
+            ratio: 4.0,          // 4:1 ratio
+            attack_coeff: 0.0,
+            release_coeff: 0.0,
+            makeup_gain_db: 0.0, // 0dB makeup gain
+            envelope_follower: 0.0,
+            sample_rate,
+        };
+        compressor.set_attack(3.0);   // 3ms attack
+        compressor.set_release(100.0); // 100ms release
+        compressor
+    }
+
+    pub fn set_attack(&mut self, attack_ms: f32) {
+        // Convert milliseconds to time constant coefficient
+        let attack_seconds = attack_ms / 1000.0;
+        self.attack_coeff = (-1.0 / (attack_seconds * self.sample_rate)).exp();
+    }
+
+    pub fn get_attack(&self) -> f32 {
+        // Convert back to milliseconds
+        if self.attack_coeff == 0.0 {
+            return 0.001;
+        }
+        -1000.0 / (self.attack_coeff.ln() * self.sample_rate)
+    }
+
+    pub fn set_release(&mut self, release_ms: f32) {
+        // Convert milliseconds to time constant coefficient
+        let release_seconds = release_ms / 1000.0;
+        self.release_coeff = (-1.0 / (release_seconds * self.sample_rate)).exp();
+    }
+
+    pub fn get_release(&self) -> f32 {
+        // Convert back to milliseconds
+        if self.release_coeff == 0.0 {
+            return 10.0;
+        }
+        -1000.0 / (self.release_coeff.ln() * self.sample_rate)
+    }
+
+    pub fn process(&mut self, input: f32) -> f32 {
+        if !self.enabled {
+            return input;
+        }
+
+        // Convert input to dB
+        let input_db = if input.abs() > 0.000001 {
+            20.0 * input.abs().log10()
+        } else {
+            -120.0 // Very quiet signal
+        };
+
+        // Envelope follower
+        let target_level = input_db;
+        if target_level > self.envelope_follower {
+            // Attack
+            self.envelope_follower = target_level + (self.envelope_follower - target_level) * self.attack_coeff;
+        } else {
+            // Release
+            self.envelope_follower = target_level + (self.envelope_follower - target_level) * self.release_coeff;
+        }
+
+        // Calculate gain reduction
+        let gain_reduction_db = if self.envelope_follower > self.threshold {
+            let over_threshold = self.envelope_follower - self.threshold;
+            over_threshold * (1.0 - 1.0 / self.ratio)
+        } else {
+            0.0
+        };
+
+        // Apply makeup gain and gain reduction
+        let total_gain_db = self.makeup_gain_db - gain_reduction_db;
+        let gain_linear = (total_gain_db * 0.05 * std::f32::consts::LN_10).exp(); // Convert dB to linear
+
+        input * gain_linear
     }
 }
 

--- a/lib/src/stage.rs
+++ b/lib/src/stage.rs
@@ -1,3 +1,4 @@
+use crate::compressor::Compressor;
 use crate::envelope::ADSRConfig;
 use crate::oscillator::Oscillator;
 
@@ -195,100 +196,6 @@ impl Stage {
     }
 }
 
-/// A compressor that applies dynamic range compression to audio signals
-pub struct Compressor {
-    pub enabled: bool,
-    pub threshold: f32,           // dB
-    pub ratio: f32,               // compression ratio (e.g., 4.0 = 4:1)
-    pub attack_coeff: f32,        // attack time coefficient
-    pub release_coeff: f32,       // release time coefficient
-    pub makeup_gain_db: f32,      // makeup gain in dB
-    envelope_follower: f32,       // current envelope level
-    sample_rate: f32,             // for calculating time constants
-}
-
-impl Compressor {
-    pub fn new(sample_rate: f32) -> Self {
-        let mut compressor = Self {
-            enabled: false,
-            threshold: -12.0,    // -12dB threshold
-            ratio: 4.0,          // 4:1 ratio
-            attack_coeff: 0.0,
-            release_coeff: 0.0,
-            makeup_gain_db: 0.0, // 0dB makeup gain
-            envelope_follower: 0.0,
-            sample_rate,
-        };
-        compressor.set_attack(3.0);   // 3ms attack
-        compressor.set_release(100.0); // 100ms release
-        compressor
-    }
-
-    pub fn set_attack(&mut self, attack_ms: f32) {
-        // Convert milliseconds to time constant coefficient
-        let attack_seconds = attack_ms / 1000.0;
-        self.attack_coeff = (-1.0 / (attack_seconds * self.sample_rate)).exp();
-    }
-
-    pub fn get_attack(&self) -> f32 {
-        // Convert back to milliseconds
-        if self.attack_coeff == 0.0 {
-            return 0.001;
-        }
-        -1000.0 / (self.attack_coeff.ln() * self.sample_rate)
-    }
-
-    pub fn set_release(&mut self, release_ms: f32) {
-        // Convert milliseconds to time constant coefficient
-        let release_seconds = release_ms / 1000.0;
-        self.release_coeff = (-1.0 / (release_seconds * self.sample_rate)).exp();
-    }
-
-    pub fn get_release(&self) -> f32 {
-        // Convert back to milliseconds
-        if self.release_coeff == 0.0 {
-            return 10.0;
-        }
-        -1000.0 / (self.release_coeff.ln() * self.sample_rate)
-    }
-
-    pub fn process(&mut self, input: f32) -> f32 {
-        if !self.enabled {
-            return input;
-        }
-
-        // Convert input to dB
-        let input_db = if input.abs() > 0.000001 {
-            20.0 * input.abs().log10()
-        } else {
-            -120.0 // Very quiet signal
-        };
-
-        // Envelope follower
-        let target_level = input_db;
-        if target_level > self.envelope_follower {
-            // Attack
-            self.envelope_follower = target_level + (self.envelope_follower - target_level) * self.attack_coeff;
-        } else {
-            // Release
-            self.envelope_follower = target_level + (self.envelope_follower - target_level) * self.release_coeff;
-        }
-
-        // Calculate gain reduction
-        let gain_reduction_db = if self.envelope_follower > self.threshold {
-            let over_threshold = self.envelope_follower - self.threshold;
-            over_threshold * (1.0 - 1.0 / self.ratio)
-        } else {
-            0.0
-        };
-
-        // Apply makeup gain and gain reduction
-        let total_gain_db = self.makeup_gain_db - gain_reduction_db;
-        let gain_linear = (total_gain_db * 0.05 * std::f32::consts::LN_10).exp(); // Convert dB to linear
-
-        input * gain_linear
-    }
-}
 
 /// A brick wall limiter that prevents audio signals from exceeding a threshold
 pub struct BrickWallLimiter {


### PR DESCRIPTION
Add optional compressor functionality to Stage with comprehensive controls:
- Compressor struct with threshold, ratio, attack, release, makeup gain
- Optional processing (can be enabled/disabled) 
- Integrated into Stage::tick() processing chain before limiter
- Complete WASM bindings for web interface
- React UI controls with real-time parameter adjustment

Processing chain: Instruments → Sum → Compressor (optional) → Limiter → Output

Resolves #17

🤖 Generated with [Claude Code](https://claude.ai/code)