### PR TITLE
feat: add tom drum instrument

### DIFF
--- a/debug-ui/app/wasm-test.tsx
+++ b/debug-ui/app/wasm-test.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import React, { useRef, useState } from 'react';
-import init, { WasmStage, WasmKickDrum, WasmHiHat, WasmSnareDrum } from '../public/wasm/oscillator.js';
+import init, { WasmStage, WasmKickDrum, WasmHiHat, WasmSnareDrum, WasmTomDrum } from '../public/wasm/oscillator.js';
 import { SpectrumAnalyzerWithRef } from './spectrum-analyzer';
 
 export default function WasmTest() {
@@ -9,15 +9,17 @@ export default function WasmTest() {
   const kickDrumRef = useRef<WasmKickDrum | null>(null);
   const hihatRef = useRef<WasmHiHat | null>(null);
   const snareRef = useRef<WasmSnareDrum | null>(null);
+  const tomRef = useRef<WasmTomDrum | null>(null);
   const audioContextRef = useRef<AudioContext | null>(null);
   const kickAudioSourceRef = useRef<AudioBufferSourceNode | null>(null);
   const hihatAudioSourceRef = useRef<AudioBufferSourceNode | null>(null);
   const snareAudioSourceRef = useRef<AudioBufferSourceNode | null>(null);
+  const tomAudioSourceRef = useRef<AudioBufferSourceNode | null>(null);
   const spectrumAnalyzerRef = useRef<{ connectSource: (source: AudioNode) => void; getAnalyser: () => AnalyserNode | null; getMonitoringNode: () => GainNode | null } | null>(null);
   const [isLoaded, setIsLoaded] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
   const [isPlaying, setIsPlaying] = useState(false);
-  const [activeTab, setActiveTab] = useState<'oscillators' | 'kick' | 'hihat' | 'snare'>('oscillators');
+  const [activeTab, setActiveTab] = useState<'oscillators' | 'kick' | 'hihat' | 'snare' | 'tom'>('oscillators');
   const [volumes, setVolumes] = useState([1.0, 1.0, 1.0, 1.0]); // Volume for each instrument
   const [frequencies, setFrequencies] = useState([200, 300, 440, 600]); // Frequency for each instrument
   const [modulatorFrequencies, setModulatorFrequencies] = useState([100, 150, 220, 300]); // Modulator frequency for each instrument (for ring modulation)
@@ -66,6 +68,17 @@ export default function WasmTest() {
     volume: 0.8,
   });
 
+  // Tom specific state
+  const [tomPreset, setTomPreset] = useState('default');
+  const [tomConfig, setTomConfig] = useState({
+    frequency: 120.0,
+    tonal: 0.8,
+    punch: 0.4,
+    decay: 0.4,
+    pitchDrop: 0.3,
+    volume: 0.8,
+  });
+
   async function loadWasm() {
     setIsLoading(true);
     try {
@@ -100,11 +113,14 @@ export default function WasmTest() {
       // Create snare instance
       snareRef.current = new WasmSnareDrum(44100);
       
+      // Create tom instance
+      tomRef.current = new WasmTomDrum(44100);
+      
       // Initialize Web Audio API
       audioContextRef.current = new AudioContext();
       
       setIsLoaded(true);
-      console.log('WASM Stage with 4 oscillators, kick drum, hi-hat, snare, and Web Audio loaded successfully!');
+      console.log('WASM Stage with 4 oscillators, kick drum, hi-hat, snare, tom, and Web Audio loaded successfully!');
     } catch (error) {
       console.error('Failed to load WASM:', error);
       alert('Failed to load WASM module: ' + String(error));
@@ -767,6 +783,139 @@ export default function WasmTest() {
     }
   }
 
+  // Tom drum functions
+  function triggerTomDrum() {
+    if (!audioContextRef.current || !tomRef.current || !isPlaying) {
+      alert('Audio not started yet. Click "Start Audio" first.');
+      return;
+    }
+
+    try {
+      // Stop any existing tom sound
+      if (tomAudioSourceRef.current) {
+        try {
+          tomAudioSourceRef.current.stop();
+        } catch (e) {
+          // Source might already be stopped, ignore error
+        }
+        tomAudioSourceRef.current = null;
+      }
+      
+      // Trigger tom
+      const currentTime = audioContextRef.current.currentTime;
+      tomRef.current.trigger(currentTime);
+      
+      // Generate audio buffer (2 seconds for tom sounds)
+      const sampleRate = audioContextRef.current.sampleRate;
+      const bufferLength = sampleRate * 2; // 2 seconds
+      const audioBuffer = audioContextRef.current.createBuffer(1, bufferLength, sampleRate);
+      
+      // Get the channel data and fill it with WASM-generated samples
+      const channelData = audioBuffer.getChannelData(0);
+      
+      for (let i = 0; i < bufferLength; i++) {
+        const time = currentTime + (i / sampleRate);
+        channelData[i] = tomRef.current.tick(time);
+      }
+      
+      // Create buffer source and play it
+      const source = audioContextRef.current.createBufferSource();
+      source.buffer = audioBuffer;
+      
+      // Connect to spectrum analyzer monitoring if available, otherwise directly to destination
+      if (spectrumAnalyzerRef.current && spectrumAnalyzerRef.current.getMonitoringNode()) {
+        source.connect(spectrumAnalyzerRef.current.getMonitoringNode()!);
+      } else {
+        source.connect(audioContextRef.current.destination);
+      }
+      
+      // Clean up reference when source ends
+      source.onended = () => {
+        tomAudioSourceRef.current = null;
+      };
+      
+      tomAudioSourceRef.current = source;
+      source.start();
+      
+      console.log('Tom drum triggered!');
+    } catch (error) {
+      console.error('Failed to trigger tom drum:', error);
+      alert('Failed to trigger tom drum');
+    }
+  }
+
+  function releaseTomDrum() {
+    if (!audioContextRef.current || !tomRef.current) {
+      alert('Audio not started yet. Click "Start Audio" first.');
+      return;
+    }
+
+    try {
+      const currentTime = audioContextRef.current.currentTime;
+      tomRef.current.release(currentTime);
+      console.log('Tom drum released!');
+    } catch (error) {
+      console.error('Failed to release tom drum:', error);
+      alert('Failed to release tom drum');
+    }
+  }
+
+  function handleTomConfigChange(param: keyof typeof tomConfig, value: number) {
+    if (!tomRef.current) return;
+    
+    // Update local state
+    setTomConfig(prev => ({ ...prev, [param]: value }));
+    
+    // Update the tom drum
+    switch (param) {
+      case 'frequency':
+        tomRef.current.set_frequency(value);
+        break;
+      case 'tonal':
+        tomRef.current.set_tonal(value);
+        break;
+      case 'punch':
+        tomRef.current.set_punch(value);
+        break;
+      case 'decay':
+        tomRef.current.set_decay(value);
+        break;
+      case 'pitchDrop':
+        tomRef.current.set_pitch_drop(value);
+        break;
+      case 'volume':
+        tomRef.current.set_volume(value);
+        break;
+    }
+  }
+
+  function handleTomPresetChange(preset: string) {
+    if (!tomRef.current) return;
+    
+    setTomPreset(preset);
+    
+    // Create new tom drum with preset
+    tomRef.current = WasmTomDrum.new_with_preset(44100, preset);
+    
+    // Update state to match preset values
+    switch (preset) {
+      case 'high_tom':
+        setTomConfig({ frequency: 180.0, tonal: 0.9, punch: 0.5, decay: 0.3, pitchDrop: 0.4, volume: 0.85 });
+        break;
+      case 'mid_tom':
+        setTomConfig({ frequency: 120.0, tonal: 0.8, punch: 0.4, decay: 0.4, pitchDrop: 0.3, volume: 0.8 });
+        break;
+      case 'low_tom':
+        setTomConfig({ frequency: 90.0, tonal: 0.7, punch: 0.3, decay: 0.6, pitchDrop: 0.2, volume: 0.85 });
+        break;
+      case 'floor_tom':
+        setTomConfig({ frequency: 70.0, tonal: 0.6, punch: 0.2, decay: 0.8, pitchDrop: 0.15, volume: 0.9 });
+        break;
+      default: // default
+        setTomConfig({ frequency: 120.0, tonal: 0.8, punch: 0.4, decay: 0.4, pitchDrop: 0.3, volume: 0.8 });
+    }
+  }
+
   return (
     <div className="p-8 max-w-7xl mx-auto">
       <h1 className="text-2xl font-bold mb-6 text-center">WASM Audio Engine Test</h1>
@@ -832,6 +981,16 @@ export default function WasmTest() {
               }`}
             >
               🥁 Snare
+            </button>
+            <button
+              onClick={() => setActiveTab('tom')}
+              className={`px-4 py-2 rounded-t-lg font-medium transition-colors ${
+                activeTab === 'tom'
+                  ? 'bg-purple-600 text-white border-b-2 border-purple-600'
+                  : 'bg-gray-700 text-gray-300 hover:bg-gray-600'
+              }`}
+            >
+              🥁 Tom
             </button>
           </div>
           
@@ -1637,6 +1796,159 @@ export default function WasmTest() {
             </button>
             </div>
           )}
+
+          {/* Tom Tab */}
+          {activeTab === 'tom' && (
+            <div>
+            <h3 className="font-semibold mb-4 text-center text-lg">🥁 Tom Drum</h3>
+            
+            {/* Tom Drum Trigger Button */}
+            <button
+              onClick={triggerTomDrum}
+              disabled={!isLoaded || !isPlaying}
+              className="w-full px-4 py-3 mb-4 bg-gradient-to-r from-purple-600 to-purple-700 text-white rounded-lg hover:from-purple-700 hover:to-purple-800 disabled:bg-gray-400 disabled:cursor-not-allowed font-semibold text-lg shadow-lg"
+            >
+              🥁 TRIGGER TOM
+            </button>
+
+            {/* Preset Selection */}
+            <div className="mb-4">
+              <label className="block text-sm font-medium mb-2">Preset</label>
+              <select
+                value={tomPreset}
+                onChange={(e) => handleTomPresetChange(e.target.value)}
+                disabled={!isLoaded}
+                className="w-full px-3 py-2 bg-gray-700 border border-gray-600 rounded disabled:cursor-not-allowed"
+              >
+                <option value="default">Default</option>
+                <option value="high_tom">High Tom</option>
+                <option value="mid_tom">Mid Tom</option>
+                <option value="low_tom">Low Tom</option>
+                <option value="floor_tom">Floor Tom</option>
+              </select>
+            </div>
+
+            {/* Tom Drum Controls */}
+            <div className="space-y-3">
+              {/* Frequency */}
+              <div className="flex items-center space-x-2">
+                <label className="w-20 text-sm font-medium">Frequency</label>
+                <input
+                  type="range"
+                  min="60"
+                  max="400"
+                  step="1"
+                  value={tomConfig.frequency}
+                  onChange={(e) => handleTomConfigChange('frequency', parseFloat(e.target.value))}
+                  disabled={!isLoaded}
+                  className="flex-1 h-2 bg-gray-200 rounded-lg appearance-none cursor-pointer disabled:cursor-not-allowed"
+                />
+                <span className="w-12 text-sm font-mono text-right">
+                  {tomConfig.frequency.toFixed(0)}Hz
+                </span>
+              </div>
+
+              {/* Volume */}
+              <div className="flex items-center space-x-2">
+                <label className="w-20 text-sm font-medium">Volume</label>
+                <input
+                  type="range"
+                  min="0"
+                  max="1"
+                  step="0.01"
+                  value={tomConfig.volume}
+                  onChange={(e) => handleTomConfigChange('volume', parseFloat(e.target.value))}
+                  disabled={!isLoaded}
+                  className="flex-1 h-2 bg-gray-200 rounded-lg appearance-none cursor-pointer disabled:cursor-not-allowed"
+                />
+                <span className="w-12 text-sm font-mono text-right">
+                  {tomConfig.volume.toFixed(2)}
+                </span>
+              </div>
+
+              {/* Decay Time */}
+              <div className="flex items-center space-x-2">
+                <label className="w-20 text-sm font-medium">Decay</label>
+                <input
+                  type="range"
+                  min="0.05"
+                  max="3"
+                  step="0.01"
+                  value={tomConfig.decay}
+                  onChange={(e) => handleTomConfigChange('decay', parseFloat(e.target.value))}
+                  disabled={!isLoaded}
+                  className="flex-1 h-2 bg-gray-200 rounded-lg appearance-none cursor-pointer disabled:cursor-not-allowed"
+                />
+                <span className="w-12 text-sm font-mono text-right">
+                  {tomConfig.decay.toFixed(2)}s
+                </span>
+              </div>
+
+              {/* Tonal Amount */}
+              <div className="flex items-center space-x-2">
+                <label className="w-20 text-sm font-medium">Tonal</label>
+                <input
+                  type="range"
+                  min="0"
+                  max="1"
+                  step="0.01"
+                  value={tomConfig.tonal}
+                  onChange={(e) => handleTomConfigChange('tonal', parseFloat(e.target.value))}
+                  disabled={!isLoaded}
+                  className="flex-1 h-2 bg-gray-200 rounded-lg appearance-none cursor-pointer disabled:cursor-not-allowed"
+                />
+                <span className="w-12 text-sm font-mono text-right">
+                  {tomConfig.tonal.toFixed(2)}
+                </span>
+              </div>
+
+              {/* Punch Amount */}
+              <div className="flex items-center space-x-2">
+                <label className="w-20 text-sm font-medium">Punch</label>
+                <input
+                  type="range"
+                  min="0"
+                  max="1"
+                  step="0.01"
+                  value={tomConfig.punch}
+                  onChange={(e) => handleTomConfigChange('punch', parseFloat(e.target.value))}
+                  disabled={!isLoaded}
+                  className="flex-1 h-2 bg-gray-200 rounded-lg appearance-none cursor-pointer disabled:cursor-not-allowed"
+                />
+                <span className="w-12 text-sm font-mono text-right">
+                  {tomConfig.punch.toFixed(2)}
+                </span>
+              </div>
+
+              {/* Pitch Drop */}
+              <div className="flex items-center space-x-2">
+                <label className="w-20 text-sm font-medium">Pitch Drop</label>
+                <input
+                  type="range"
+                  min="0"
+                  max="1"
+                  step="0.01"
+                  value={tomConfig.pitchDrop}
+                  onChange={(e) => handleTomConfigChange('pitchDrop', parseFloat(e.target.value))}
+                  disabled={!isLoaded}
+                  className="flex-1 h-2 bg-gray-200 rounded-lg appearance-none cursor-pointer disabled:cursor-not-allowed"
+                />
+                <span className="w-12 text-sm font-mono text-right">
+                  {tomConfig.pitchDrop.toFixed(2)}
+                </span>
+              </div>
+            </div>
+
+            {/* Release Button */}
+            <button
+              onClick={releaseTomDrum}
+              disabled={!isLoaded || !isPlaying}
+              className="w-full mt-4 px-4 py-2 bg-gray-600 text-white rounded hover:bg-gray-500 disabled:bg-gray-700 disabled:cursor-not-allowed"
+            >
+              Release Tom
+            </button>
+            </div>
+          )}
         </div>
         </div>
         
@@ -1659,6 +1971,7 @@ export default function WasmTest() {
             <p>Kick Drum: {isLoaded && kickDrumRef.current ? '✅ Loaded' : '❌ Not loaded'}</p>
             <p>Hi-Hat: {isLoaded && hihatRef.current ? '✅ Loaded' : '❌ Not loaded'}</p>
             <p>Snare: {isLoaded && snareRef.current ? '✅ Loaded' : '❌ Not loaded'}</p>
+            <p>Tom: {isLoaded && tomRef.current ? '✅ Loaded' : '❌ Not loaded'}</p>
             <p>Audio Context: {audioContextRef.current ? '✅ Ready' : '❌ No'}</p>
             <p>Audio Playing: {isPlaying ? '✅ Yes' : '❌ No'}</p>
           </div>
@@ -1687,6 +2000,9 @@ export default function WasmTest() {
           <li>• <strong>Snare Instrument</strong>: Comprehensive 3-layer snare drum with tonal, noise, and crack components</li>
           <li>• <strong>Snare Presets</strong>: Built-in presets (Default, Crispy, Deep, Tight, Fat) for different snare styles</li>
           <li>• <strong>Snare Parameters</strong>: Frequency, tonal amount, noise amount, crack amount, decay time, and pitch drop controls</li>
+          <li>• <strong>Tom Instrument</strong>: Clean 2-layer tom drum with tonal body and punch attack components</li>
+          <li>• <strong>Tom Presets</strong>: Built-in presets (Default, High Tom, Mid Tom, Low Tom, Floor Tom) for different tom types</li>
+          <li>• <strong>Tom Parameters</strong>: Frequency, tonal amount, punch amount, decay time, and pitch drop controls</li>
           <li>• <strong>Audio mixing</strong>: Stage.tick() sums all instrument outputs with controls applied</li>
         </ul>
       </div>
@@ -1694,7 +2010,7 @@ export default function WasmTest() {
       <div className="mt-4 p-4 bg-yellow-900/20 border border-yellow-600/30 rounded">
         <h3 className="font-semibold mb-2 text-yellow-300">Instructions:</h3>
         <ol className="list-decimal list-inside text-sm space-y-1 text-yellow-100">
-          <li>Click "Load Audio Engine" to initialize the WASM Stage with 4 oscillators, kick drum, hi-hat, and snare</li>
+          <li>Click "Load Audio Engine" to initialize the WASM Stage with 4 oscillators, kick drum, hi-hat, snare, and tom</li>
           <li>Click "Start Audio" to begin audio processing</li>
           <li>Use individual instrument buttons to test single oscillators</li>
           <li>Adjust instrument controls for each oscillator:</li>
@@ -1745,6 +2061,15 @@ export default function WasmTest() {
             <li><strong>Crack Amount:</strong> Control high-frequency snap and crack</li>
             <li><strong>Decay Time:</strong> Adjust overall decay time (0.01-2s)</li>
             <li><strong>Pitch Drop:</strong> Control frequency sweep effect for realistic sound</li>
+          </ul>
+          <li>Test the tom drum instrument with its dedicated section:</li>
+          <ul className="list-disc list-inside ml-4 text-xs space-y-0.5 text-yellow-200">
+            <li><strong>Presets:</strong> Try different tom types (Default, High Tom, Mid Tom, Low Tom, Floor Tom)</li>
+            <li><strong>Frequency:</strong> Adjust fundamental frequency (60-400Hz)</li>
+            <li><strong>Tonal Amount:</strong> Control the main body and resonance of the tom</li>
+            <li><strong>Punch Amount:</strong> Control the attack transient and punch character</li>
+            <li><strong>Decay Time:</strong> Adjust overall decay time (0.05-3s)</li>
+            <li><strong>Pitch Drop:</strong> Control frequency sweep effect for realistic tom sound</li>
           </ul>
         </ol>
       </div>

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -7,6 +7,7 @@ pub mod kick;
 pub mod oscillator;
 pub mod snare;
 pub mod stage;
+pub mod tom;
 pub mod waveform;
 
 // WASM bindings (web)
@@ -18,6 +19,7 @@ pub mod web {
     use super::oscillator::Oscillator;
     use super::snare::{SnareConfig, SnareDrum};
     use super::stage::Stage;
+    use super::tom::{TomConfig, TomDrum};
     use wasm_bindgen::prelude::*;
 
     #[wasm_bindgen]
@@ -526,6 +528,106 @@ pub mod web {
                 volume,
             );
             self.snare_drum.set_config(config);
+        }
+    }
+
+    #[wasm_bindgen]
+    pub struct WasmTomDrum {
+        tom_drum: TomDrum,
+    }
+
+    #[wasm_bindgen]
+    impl WasmTomDrum {
+        #[wasm_bindgen(constructor)]
+        pub fn new(sample_rate: f32) -> WasmTomDrum {
+            WasmTomDrum {
+                tom_drum: TomDrum::new(sample_rate),
+            }
+        }
+
+        #[wasm_bindgen]
+        pub fn new_with_preset(sample_rate: f32, preset_name: &str) -> WasmTomDrum {
+            let config = match preset_name {
+                "high_tom" => TomConfig::high_tom(),
+                "mid_tom" => TomConfig::mid_tom(),
+                "low_tom" => TomConfig::low_tom(),
+                "floor_tom" => TomConfig::floor_tom(),
+                _ => TomConfig::default(),
+            };
+            WasmTomDrum {
+                tom_drum: TomDrum::with_config(sample_rate, config),
+            }
+        }
+
+        #[wasm_bindgen]
+        pub fn trigger(&mut self, time: f32) {
+            self.tom_drum.trigger(time);
+        }
+
+        #[wasm_bindgen]
+        pub fn release(&mut self, time: f32) {
+            self.tom_drum.release(time);
+        }
+
+        #[wasm_bindgen]
+        pub fn tick(&mut self, current_time: f32) -> f32 {
+            self.tom_drum.tick(current_time)
+        }
+
+        #[wasm_bindgen]
+        pub fn is_active(&self) -> bool {
+            self.tom_drum.is_active()
+        }
+
+        #[wasm_bindgen]
+        pub fn set_volume(&mut self, volume: f32) {
+            self.tom_drum.set_volume(volume);
+        }
+
+        #[wasm_bindgen]
+        pub fn set_frequency(&mut self, frequency: f32) {
+            self.tom_drum.set_frequency(frequency);
+        }
+
+        #[wasm_bindgen]
+        pub fn set_decay(&mut self, decay_time: f32) {
+            self.tom_drum.set_decay(decay_time);
+        }
+
+        #[wasm_bindgen]
+        pub fn set_tonal(&mut self, tonal_amount: f32) {
+            self.tom_drum.set_tonal(tonal_amount);
+        }
+
+        #[wasm_bindgen]
+        pub fn set_punch(&mut self, punch_amount: f32) {
+            self.tom_drum.set_punch(punch_amount);
+        }
+
+        #[wasm_bindgen]
+        pub fn set_pitch_drop(&mut self, pitch_drop: f32) {
+            self.tom_drum.set_pitch_drop(pitch_drop);
+        }
+
+        #[wasm_bindgen]
+        pub fn set_config(
+            &mut self,
+            tom_frequency: f32,
+            tonal_amount: f32,
+            punch_amount: f32,
+            decay_time: f32,
+            pitch_drop: f32,
+            volume: f32,
+        ) {
+            let config = TomConfig::new(
+                tom_frequency,
+                tonal_amount,
+                punch_amount,
+                decay_time,
+                pitch_drop,
+                volume,
+            );
+            self.tom_drum.set_config(config);
         }
     }
 }

--- a/lib/src/tom.rs
+++ b/lib/src/tom.rs
@@ -1,0 +1,220 @@
+use crate::envelope::{ADSRConfig, Envelope};
+use crate::oscillator::Oscillator;
+use crate::waveform::Waveform;
+
+#[derive(Clone, Copy, Debug)]
+pub struct TomConfig {
+    pub tom_frequency: f32,  // Base frequency (80-300Hz typical for toms)
+    pub tonal_amount: f32,   // Tonal component presence (0.0-1.0)
+    pub punch_amount: f32,   // Attack/punch component presence (0.0-1.0)
+    pub decay_time: f32,     // Overall decay length in seconds
+    pub pitch_drop: f32,     // Frequency sweep amount (0.0-1.0)
+    pub volume: f32,         // Overall volume (0.0-1.0)
+}
+
+impl TomConfig {
+    pub fn new(
+        tom_frequency: f32,
+        tonal_amount: f32,
+        punch_amount: f32,
+        decay_time: f32,
+        pitch_drop: f32,
+        volume: f32,
+    ) -> Self {
+        Self {
+            tom_frequency: tom_frequency.max(60.0).min(400.0), // Reasonable tom range
+            tonal_amount: tonal_amount.clamp(0.0, 1.0),
+            punch_amount: punch_amount.clamp(0.0, 1.0),
+            decay_time: decay_time.max(0.05).min(3.0), // Reasonable decay range for toms
+            pitch_drop: pitch_drop.clamp(0.0, 1.0),
+            volume: volume.clamp(0.0, 1.0),
+        }
+    }
+
+    pub fn default() -> Self {
+        Self::new(120.0, 0.8, 0.4, 0.4, 0.3, 0.8)
+    }
+
+    pub fn high_tom() -> Self {
+        Self::new(180.0, 0.9, 0.5, 0.3, 0.4, 0.85)
+    }
+
+    pub fn mid_tom() -> Self {
+        Self::new(120.0, 0.8, 0.4, 0.4, 0.3, 0.8)
+    }
+
+    pub fn low_tom() -> Self {
+        Self::new(90.0, 0.7, 0.3, 0.6, 0.2, 0.85)
+    }
+
+    pub fn floor_tom() -> Self {
+        Self::new(70.0, 0.6, 0.2, 0.8, 0.15, 0.9)
+    }
+}
+
+pub struct TomDrum {
+    pub sample_rate: f32,
+    pub config: TomConfig,
+
+    // Two oscillators for tom character
+    pub tonal_oscillator: Oscillator,  // Main tonal component (sine/triangle)
+    pub punch_oscillator: Oscillator,  // Attack/punch component
+
+    // Pitch envelope for frequency sweeping
+    pub pitch_envelope: Envelope,
+    pub base_frequency: f32,
+    pub pitch_start_multiplier: f32,
+
+    pub is_active: bool,
+}
+
+impl TomDrum {
+    pub fn new(sample_rate: f32) -> Self {
+        let config = TomConfig::default();
+        Self::with_config(sample_rate, config)
+    }
+
+    pub fn with_config(sample_rate: f32, config: TomConfig) -> Self {
+        let mut tom = Self {
+            sample_rate,
+            config,
+            tonal_oscillator: Oscillator::new(sample_rate, config.tom_frequency),
+            punch_oscillator: Oscillator::new(sample_rate, config.tom_frequency * 3.0),
+            pitch_envelope: Envelope::new(),
+            base_frequency: config.tom_frequency,
+            pitch_start_multiplier: 1.0 + config.pitch_drop * 1.0, // More subtle pitch drop than snare
+            is_active: false,
+        };
+
+        tom.configure_oscillators();
+        tom
+    }
+
+    fn configure_oscillators(&mut self) {
+        let config = self.config;
+
+        // Tonal oscillator: Sine wave for body/tone
+        self.tonal_oscillator.waveform = Waveform::Sine;
+        self.tonal_oscillator.frequency_hz = config.tom_frequency;
+        self.tonal_oscillator
+            .set_volume(config.tonal_amount * config.volume);
+        self.tonal_oscillator.set_adsr(ADSRConfig::new(
+            0.001,                    // Very fast attack
+            config.decay_time * 0.9,  // Main decay
+            0.1,                      // Low sustain for drum character
+            config.decay_time * 0.3,  // Medium release
+        ));
+
+        // Punch oscillator: Triangle wave for attack character
+        self.punch_oscillator.waveform = Waveform::Triangle;
+        self.punch_oscillator.frequency_hz = config.tom_frequency * 3.0;
+        self.punch_oscillator
+            .set_volume(config.punch_amount * config.volume * 0.6);
+        self.punch_oscillator.set_adsr(ADSRConfig::new(
+            0.001,                    // Very fast attack
+            config.decay_time * 0.3,  // Short decay for punch
+            0.0,                      // No sustain for punch
+            config.decay_time * 0.1,  // Quick release
+        ));
+
+        // Pitch envelope: Fast attack, medium decay for frequency sweeping
+        self.pitch_envelope.set_config(ADSRConfig::new(
+            0.001,                    // Instant attack
+            config.decay_time * 0.4,  // Medium pitch drop
+            0.0,                      // Drop to base frequency
+            config.decay_time * 0.2,  // Medium release
+        ));
+    }
+
+    pub fn set_config(&mut self, config: TomConfig) {
+        self.config = config;
+        self.base_frequency = config.tom_frequency;
+        self.pitch_start_multiplier = 1.0 + config.pitch_drop * 1.0;
+        self.configure_oscillators();
+    }
+
+    pub fn trigger(&mut self, time: f32) {
+        self.is_active = true;
+
+        // Trigger both oscillators
+        self.tonal_oscillator.trigger(time);
+        self.punch_oscillator.trigger(time);
+
+        // Trigger pitch envelope
+        self.pitch_envelope.trigger(time);
+    }
+
+    pub fn release(&mut self, time: f32) {
+        if self.is_active {
+            self.tonal_oscillator.release(time);
+            self.punch_oscillator.release(time);
+            self.pitch_envelope.release(time);
+        }
+    }
+
+    pub fn tick(&mut self, current_time: f32) -> f32 {
+        if !self.is_active {
+            return 0.0;
+        }
+
+        // Calculate pitch modulation
+        let pitch_envelope_value = self.pitch_envelope.get_amplitude(current_time);
+        let frequency_multiplier = 1.0 + (self.pitch_start_multiplier - 1.0) * pitch_envelope_value;
+
+        // Apply pitch envelope to tonal oscillator
+        self.tonal_oscillator.frequency_hz = self.base_frequency * frequency_multiplier;
+
+        // Punch oscillator gets a more subtle pitch modulation
+        self.punch_oscillator.frequency_hz = self.base_frequency * 3.0 * (1.0 + (frequency_multiplier - 1.0) * 0.5);
+
+        // Sum oscillator outputs
+        let tonal_output = self.tonal_oscillator.tick(current_time);
+        let punch_output = self.punch_oscillator.tick(current_time);
+
+        let total_output = tonal_output + punch_output;
+
+        // Check if tom is still active
+        if !self.tonal_oscillator.envelope.is_active
+            && !self.punch_oscillator.envelope.is_active
+        {
+            self.is_active = false;
+        }
+
+        total_output
+    }
+
+    pub fn is_active(&self) -> bool {
+        self.is_active
+    }
+
+    pub fn set_volume(&mut self, volume: f32) {
+        self.config.volume = volume.clamp(0.0, 1.0);
+        self.configure_oscillators();
+    }
+
+    pub fn set_frequency(&mut self, frequency: f32) {
+        self.config.tom_frequency = frequency.max(60.0).min(400.0);
+        self.base_frequency = self.config.tom_frequency;
+        self.configure_oscillators();
+    }
+
+    pub fn set_decay(&mut self, decay_time: f32) {
+        self.config.decay_time = decay_time.max(0.05).min(3.0);
+        self.configure_oscillators();
+    }
+
+    pub fn set_tonal(&mut self, tonal_amount: f32) {
+        self.config.tonal_amount = tonal_amount.clamp(0.0, 1.0);
+        self.configure_oscillators();
+    }
+
+    pub fn set_punch(&mut self, punch_amount: f32) {
+        self.config.punch_amount = punch_amount.clamp(0.0, 1.0);
+        self.configure_oscillators();
+    }
+
+    pub fn set_pitch_drop(&mut self, pitch_drop: f32) {
+        self.config.pitch_drop = pitch_drop.clamp(0.0, 1.0);
+        self.pitch_start_multiplier = 1.0 + self.config.pitch_drop * 1.0;
+    }
+}


### PR DESCRIPTION
Resolves #38

Adds a complete tom drum instrument following existing patterns:

- **Tom Drum Implementation**: 2-oscillator design with tonal + punch components
- **4 Presets**: Default, High Tom, Mid Tom, Low Tom, Floor Tom
- **WASM Bindings**: Full parameter control and preset support
- **Debug UI**: Complete tom tab with all controls and presets
- **Documentation**: Updated all help text and status indicators

Generated with [Claude Code](https://claude.ai/code)