### PR TITLE
feat: implement 16-step drum sequencer

### DIFF
--- a/debug-ui/app/sequencer.tsx
+++ b/debug-ui/app/sequencer.tsx
@@ -1,0 +1,214 @@
+'use client';
+
+import React, { useState, useEffect } from 'react';
+import { WasmStage } from '../public/wasm/oscillator.js';
+
+interface SequencerProps {
+  stage: WasmStage | null;
+  isPlaying: boolean;
+}
+
+export default function Sequencer({ stage, isPlaying }: SequencerProps) {
+  const [patterns, setPatterns] = useState<boolean[][]>([
+    new Array(16).fill(false), // Bass Drum
+    new Array(16).fill(false), // Snare
+    new Array(16).fill(false), // Hi-hat  
+    new Array(16).fill(false), // Cymbal
+  ]);
+  const [currentStep, setCurrentStep] = useState(0);
+  const [bpm, setBpm] = useState(120);
+  const [sequencerPlaying, setSequencerPlaying] = useState(false);
+
+  const instrumentNames = ['Bass', 'Snare', 'Hi-hat', 'Cymbal'];
+  const instrumentColors = [
+    'bg-red-600 hover:bg-red-700',     // Bass - Red
+    'bg-blue-600 hover:bg-blue-700',   // Snare - Blue  
+    'bg-yellow-600 hover:bg-yellow-700', // Hi-hat - Yellow
+    'bg-purple-600 hover:bg-purple-700', // Cymbal - Purple
+  ];
+
+  // Update current step display
+  useEffect(() => {
+    if (!stage || !sequencerPlaying) return;
+
+    const interval = setInterval(() => {
+      if (stage) {
+        const step = stage.sequencer_get_current_step();
+        setCurrentStep(step);
+      }
+    }, 50); // Update every 50ms for smooth animation
+
+    return () => clearInterval(interval);
+  }, [stage, sequencerPlaying]);
+
+  // Sync patterns from WASM
+  useEffect(() => {
+    if (!stage) return;
+    
+    const syncedPatterns = patterns.map((pattern, instrumentIndex) =>
+      pattern.map((_, stepIndex) => stage.sequencer_get_step(instrumentIndex, stepIndex))
+    );
+    setPatterns(syncedPatterns);
+  }, [stage]);
+
+  const toggleStep = (instrumentIndex: number, stepIndex: number) => {
+    if (!stage) return;
+
+    const newValue = !patterns[instrumentIndex][stepIndex];
+    stage.sequencer_set_step(instrumentIndex, stepIndex, newValue);
+    
+    setPatterns(prev => {
+      const newPatterns = [...prev];
+      newPatterns[instrumentIndex] = [...newPatterns[instrumentIndex]];
+      newPatterns[instrumentIndex][stepIndex] = newValue;
+      return newPatterns;
+    });
+  };
+
+  const handlePlay = () => {
+    if (!stage) return;
+    
+    if (sequencerPlaying) {
+      stage.sequencer_stop();
+      setSequencerPlaying(false);
+    } else {
+      stage.sequencer_play();
+      setSequencerPlaying(true);
+    }
+  };
+
+  const handleReset = () => {
+    if (!stage) return;
+    
+    stage.sequencer_reset();
+    setCurrentStep(0);
+  };
+
+  const handleClearAll = () => {
+    if (!stage) return;
+    
+    stage.sequencer_clear_all();
+    setPatterns([
+      new Array(16).fill(false),
+      new Array(16).fill(false), 
+      new Array(16).fill(false),
+      new Array(16).fill(false),
+    ]);
+  };
+
+  const handleBpmChange = (newBpm: number) => {
+    if (!stage) return;
+    
+    stage.sequencer_set_bpm(newBpm);
+    setBpm(newBpm);
+  };
+
+  if (!stage) {
+    return (
+      <div className="sequencer-container bg-gray-800 p-4 rounded-lg border border-gray-600">
+        <h3 className="text-lg font-semibold text-white mb-3">16-Step Sequencer</h3>
+        <div className="text-gray-400">WASM not loaded</div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="sequencer-container bg-gray-800 p-4 rounded-lg border border-gray-600">
+      <div className="flex items-center justify-between mb-4">
+        <h3 className="text-lg font-semibold text-white">16-Step Sequencer</h3>
+        <div className="flex items-center space-x-2">
+          <div className={`w-3 h-3 rounded-full ${sequencerPlaying ? 'bg-green-500' : 'bg-gray-500'}`}></div>
+          <span className="text-sm text-gray-300">
+            {sequencerPlaying ? 'Playing' : 'Stopped'}
+          </span>
+        </div>
+      </div>
+
+      {/* Transport Controls */}
+      <div className="flex items-center space-x-3 mb-4">
+        <button
+          onClick={handlePlay}
+          className={`px-4 py-2 rounded font-medium ${
+            sequencerPlaying 
+              ? 'bg-red-600 hover:bg-red-700' 
+              : 'bg-green-600 hover:bg-green-700'
+          } text-white transition-colors`}
+        >
+          {sequencerPlaying ? '⏸ Stop' : '▶ Play'}
+        </button>
+        
+        <button
+          onClick={handleReset}
+          className="px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded font-medium transition-colors"
+        >
+          ⏮ Reset
+        </button>
+        
+        <button
+          onClick={handleClearAll}
+          className="px-4 py-2 bg-orange-600 hover:bg-orange-700 text-white rounded font-medium transition-colors"
+        >
+          🗑 Clear
+        </button>
+      </div>
+
+      {/* BPM Control */}
+      <div className="flex items-center space-x-3 mb-4">
+        <label className="text-white font-medium min-w-fit">BPM:</label>
+        <input
+          type="range"
+          min="60"
+          max="180"
+          value={bpm}
+          onChange={(e) => handleBpmChange(parseInt(e.target.value))}
+          className="flex-1"
+        />
+        <span className="text-white font-mono min-w-fit">{bpm}</span>
+      </div>
+
+      {/* Step Grid */}
+      <div className="overflow-x-auto">
+        <div className="min-w-fit">
+          {/* Step numbers header */}
+          <div className="flex mb-2">
+            <div className="w-24 flex-shrink-0"></div>
+            {Array.from({ length: 16 }, (_, i) => (
+              <div key={i} className="w-8 h-6 flex items-center justify-center text-xs text-gray-400 flex-shrink-0">
+                {i + 1}
+              </div>
+            ))}
+          </div>
+
+          {/* Instrument rows */}
+          {instrumentNames.map((name, instrumentIndex) => (
+            <div key={instrumentIndex} className="flex items-center mb-2">
+              <div className="w-24 text-sm text-white font-medium text-right pr-3 flex-shrink-0">
+                {name}
+              </div>
+              {Array.from({ length: 16 }, (_, stepIndex) => (
+                <button
+                  key={stepIndex}
+                  onClick={() => toggleStep(instrumentIndex, stepIndex)}
+                  className={`w-8 h-8 rounded border-2 mr-1 transition-all flex-shrink-0 ${
+                    patterns[instrumentIndex][stepIndex]
+                      ? `${instrumentColors[instrumentIndex]} border-white`
+                      : 'bg-gray-700 hover:bg-gray-600 border-gray-500 hover:border-gray-400'
+                  } ${
+                    stepIndex === currentStep && sequencerPlaying
+                      ? 'ring-2 ring-white animate-pulse'
+                      : ''
+                  }`}
+                  disabled={!isPlaying}
+                />
+              ))}
+            </div>
+          ))}
+        </div>
+      </div>
+
+      <div className="mt-3 text-xs text-gray-400">
+        Click checkboxes to program patterns. Current step: {currentStep + 1}/16
+      </div>
+    </div>
+  );
+}

--- a/debug-ui/app/sequencer.tsx
+++ b/debug-ui/app/sequencer.tsx
@@ -11,21 +11,21 @@ interface SequencerProps {
 
 export default function Sequencer({ stage, isPlaying, audioContext }: SequencerProps) {
   const [patterns, setPatterns] = useState<boolean[][]>([
-    new Array(16).fill(false), // Bass Drum
+    new Array(16).fill(false), // Kick Drum
     new Array(16).fill(false), // Snare
     new Array(16).fill(false), // Hi-hat  
-    new Array(16).fill(false), // Cymbal
+    new Array(16).fill(false), // Tom
   ]);
   const [currentStep, setCurrentStep] = useState(0);
   const [bpm, setBpm] = useState(120);
   const [sequencerPlaying, setSequencerPlaying] = useState(false);
 
-  const instrumentNames = ['Bass', 'Snare', 'Hi-hat', 'Cymbal'];
+  const instrumentNames = ['Kick', 'Snare', 'Hi-hat', 'Tom'];
   const instrumentColors = [
-    'bg-red-600 hover:bg-red-700',     // Bass - Red
+    'bg-red-600 hover:bg-red-700',     // Kick - Red
     'bg-blue-600 hover:bg-blue-700',   // Snare - Blue  
     'bg-yellow-600 hover:bg-yellow-700', // Hi-hat - Yellow
-    'bg-purple-600 hover:bg-purple-700', // Cymbal - Purple
+    'bg-purple-600 hover:bg-purple-700', // Tom - Purple
   ];
 
   // Update current step display
@@ -46,20 +46,25 @@ export default function Sequencer({ stage, isPlaying, audioContext }: SequencerP
   useEffect(() => {
     if (!stage) return;
     
-    // Set up a default pattern for testing
-    // Bass drum on steps 1, 5, 9, 13 (beats 1, 2, 3, 4)
-    stage.sequencer_set_step(0, 0, true);
-    stage.sequencer_set_step(0, 4, true);
-    stage.sequencer_set_step(0, 8, true);
-    stage.sequencer_set_step(0, 12, true);
-    
-    // Snare on steps 5, 13 (beats 2, 4)
-    stage.sequencer_set_step(1, 4, true);
-    stage.sequencer_set_step(1, 12, true);
-    
-    // Hi-hat on every other step
-    for (let i = 0; i < 16; i += 2) {
-      stage.sequencer_set_step(2, i, true);
+    // Use the new default pattern setup method
+    if (typeof stage.sequencer_set_default_patterns === 'function') {
+      stage.sequencer_set_default_patterns();
+    } else {
+      // Fallback to manual setup for backwards compatibility
+      // Kick drum on steps 1, 5, 9, 13 (beats 1, 2, 3, 4)
+      stage.sequencer_set_step(0, 0, true);
+      stage.sequencer_set_step(0, 4, true);
+      stage.sequencer_set_step(0, 8, true);
+      stage.sequencer_set_step(0, 12, true);
+      
+      // Snare on steps 5, 13 (beats 2, 4)
+      stage.sequencer_set_step(1, 4, true);
+      stage.sequencer_set_step(1, 12, true);
+      
+      // Hi-hat on every other step
+      for (let i = 0; i < 16; i += 2) {
+        stage.sequencer_set_step(2, i, true);
+      }
     }
     
     const syncedPatterns = patterns.map((pattern, instrumentIndex) =>

--- a/debug-ui/app/wasm-test.tsx
+++ b/debug-ui/app/wasm-test.tsx
@@ -48,7 +48,7 @@ export default function WasmTest() {
     100, 150, 220, 300,
   ]); // Modulator frequency for each instrument (for ring modulation)
   const [waveforms, setWaveforms] = useState([1, 1, 1, 1]); // Waveform for each instrument (0=Sine, 1=Square, 2=Saw, 3=Triangle)
-  const [enabled, setEnabled] = useState([true, true, true, true]); // Enabled state for each instrument
+  const [enabled, setEnabled] = useState([false, false, false, false]); // Enabled state for each instrument - disabled by default
   const [adsrValues, setAdsrValues] = useState([
     { attack: 0.01, decay: 0.1, sustain: 0.7, release: 0.3 }, // Bass Drum
     { attack: 0.001, decay: 0.05, sustain: 0.3, release: 0.1 }, // Snare
@@ -212,6 +212,11 @@ export default function WasmTest() {
       // Initialize modulator frequencies for each instrument
       modulatorFrequencies.forEach((freq, index) => {
         stageRef.current?.set_instrument_modulator_frequency(index, freq);
+      });
+
+      // Initialize enabled state for each instrument (basic oscillators disabled by default)
+      enabled.forEach((isEnabled, index) => {
+        stageRef.current?.set_instrument_enabled(index, isEnabled);
       });
 
       // Create kick drum instance

--- a/debug-ui/app/wasm-test.tsx
+++ b/debug-ui/app/wasm-test.tsx
@@ -3,6 +3,7 @@
 import React, { useRef, useState } from 'react';
 import init, { WasmStage, WasmKickDrum, WasmHiHat, WasmSnareDrum, WasmTomDrum } from '../public/wasm/oscillator.js';
 import { SpectrumAnalyzerWithRef } from './spectrum-analyzer';
+import Sequencer from './sequencer';
 
 export default function WasmTest() {
   const stageRef = useRef<WasmStage | null>(null);
@@ -1964,6 +1965,12 @@ export default function WasmTest() {
               height={200}
             />
           </div>
+
+          {/* Sequencer */}
+          <Sequencer
+            stage={stageRef.current}
+            isPlaying={isPlaying}
+          />
           
           <div className="p-4 bg-gray-800 rounded">
             <h2 className="font-semibold mb-2">Status:</h2>

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -193,6 +193,58 @@ pub mod web {
         pub fn is_instrument_enabled(&self, index: usize) -> bool {
             self.stage.is_instrument_enabled(index)
         }
+
+        // Sequencer methods
+        
+        #[wasm_bindgen]
+        pub fn sequencer_play(&mut self) {
+            self.stage.sequencer_play();
+        }
+        
+        #[wasm_bindgen]
+        pub fn sequencer_stop(&mut self) {
+            self.stage.sequencer_stop();
+        }
+        
+        #[wasm_bindgen]
+        pub fn sequencer_reset(&mut self) {
+            self.stage.sequencer_reset();
+        }
+        
+        #[wasm_bindgen]
+        pub fn sequencer_clear_all(&mut self) {
+            self.stage.sequencer_clear_all();
+        }
+        
+        #[wasm_bindgen]
+        pub fn sequencer_set_step(&mut self, instrument: usize, step: usize, enabled: bool) {
+            self.stage.sequencer_set_step(instrument, step, enabled);
+        }
+        
+        #[wasm_bindgen]
+        pub fn sequencer_get_step(&self, instrument: usize, step: usize) -> bool {
+            self.stage.sequencer_get_step(instrument, step)
+        }
+        
+        #[wasm_bindgen]
+        pub fn sequencer_set_bpm(&mut self, bpm: f32) {
+            self.stage.sequencer_set_bpm(bpm);
+        }
+        
+        #[wasm_bindgen]
+        pub fn sequencer_get_bpm(&self) -> f32 {
+            self.stage.sequencer_get_bpm()
+        }
+        
+        #[wasm_bindgen]
+        pub fn sequencer_get_current_step(&self) -> usize {
+            self.stage.sequencer_get_current_step()
+        }
+        
+        #[wasm_bindgen]
+        pub fn sequencer_is_playing(&self) -> bool {
+            self.stage.sequencer_is_playing()
+        }
     }
 
     #[wasm_bindgen]

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -195,52 +195,51 @@ pub mod web {
         }
 
         // Sequencer methods
-        
         #[wasm_bindgen]
         pub fn sequencer_play(&mut self) {
             self.stage.sequencer_play();
         }
-        
+
         #[wasm_bindgen]
         pub fn sequencer_stop(&mut self) {
             self.stage.sequencer_stop();
         }
-        
+
         #[wasm_bindgen]
         pub fn sequencer_reset(&mut self) {
             self.stage.sequencer_reset();
         }
-        
+
         #[wasm_bindgen]
         pub fn sequencer_clear_all(&mut self) {
             self.stage.sequencer_clear_all();
         }
-        
+
         #[wasm_bindgen]
         pub fn sequencer_set_step(&mut self, instrument: usize, step: usize, enabled: bool) {
             self.stage.sequencer_set_step(instrument, step, enabled);
         }
-        
+
         #[wasm_bindgen]
         pub fn sequencer_get_step(&self, instrument: usize, step: usize) -> bool {
             self.stage.sequencer_get_step(instrument, step)
         }
-        
+
         #[wasm_bindgen]
         pub fn sequencer_set_bpm(&mut self, bpm: f32) {
             self.stage.sequencer_set_bpm(bpm);
         }
-        
+
         #[wasm_bindgen]
         pub fn sequencer_get_bpm(&self) -> f32 {
             self.stage.sequencer_get_bpm()
         }
-        
+
         #[wasm_bindgen]
         pub fn sequencer_get_current_step(&self) -> usize {
             self.stage.sequencer_get_current_step()
         }
-        
+
         #[wasm_bindgen]
         pub fn sequencer_is_playing(&self) -> bool {
             self.stage.sequencer_is_playing()

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -249,6 +249,107 @@ pub mod web {
         pub fn sequencer_is_playing(&self) -> bool {
             self.stage.sequencer_is_playing()
         }
+        
+        #[wasm_bindgen]
+        pub fn sequencer_set_default_patterns(&mut self) {
+            self.stage.sequencer_set_default_patterns();
+        }
+        
+        // Drum configuration getters
+        #[wasm_bindgen]
+        pub fn get_kick_frequency(&self) -> f32 {
+            self.stage.get_kick_config().kick_frequency
+        }
+        
+        #[wasm_bindgen]
+        pub fn get_snare_frequency(&self) -> f32 {
+            self.stage.get_snare_config().snare_frequency
+        }
+        
+        #[wasm_bindgen]
+        pub fn get_hihat_frequency(&self) -> f32 {
+            self.stage.get_hihat_config().base_frequency
+        }
+        
+        #[wasm_bindgen]
+        pub fn get_tom_frequency(&self) -> f32 {
+            self.stage.get_tom_config().tom_frequency
+        }
+        
+        // Drum configuration setters
+        #[wasm_bindgen]
+        pub fn set_kick_config(&mut self, frequency: f32, punch: f32, sub: f32, click: f32, decay: f32, pitch_drop: f32, volume: f32) {
+            let config = KickConfig::new(frequency, punch, sub, click, decay, pitch_drop, volume);
+            self.stage.set_kick_config(config);
+        }
+        
+        #[wasm_bindgen]
+        pub fn set_snare_config(&mut self, frequency: f32, tonal: f32, noise: f32, crack: f32, decay: f32, pitch_drop: f32, volume: f32) {
+            let config = SnareConfig::new(frequency, tonal, noise, crack, decay, pitch_drop, volume);
+            self.stage.set_snare_config(config);
+        }
+        
+        #[wasm_bindgen]
+        pub fn set_hihat_config(&mut self, frequency: f32, resonance: f32, brightness: f32, decay: f32, attack: f32, volume: f32, is_open: bool) {
+            let config = HiHatConfig::new(frequency, resonance, brightness, decay, attack, volume, is_open);
+            self.stage.set_hihat_config(config);
+        }
+        
+        #[wasm_bindgen]
+        pub fn set_tom_config(&mut self, frequency: f32, tonal: f32, punch: f32, decay: f32, pitch_drop: f32, volume: f32) {
+            let config = TomConfig::new(frequency, tonal, punch, decay, pitch_drop, volume);
+            self.stage.set_tom_config(config);
+        }
+        
+        // Drum preset loaders
+        #[wasm_bindgen]
+        pub fn load_kick_preset(&mut self, preset_name: &str) {
+            let config = match preset_name {
+                "punchy" => KickConfig::punchy(),
+                "deep" => KickConfig::deep(),
+                "tight" => KickConfig::tight(),
+                _ => KickConfig::default(),
+            };
+            self.stage.set_kick_config(config);
+        }
+        
+        #[wasm_bindgen]
+        pub fn load_snare_preset(&mut self, preset_name: &str) {
+            let config = match preset_name {
+                "crispy" => SnareConfig::crispy(),
+                "deep" => SnareConfig::deep(),
+                "tight" => SnareConfig::tight(),
+                "fat" => SnareConfig::fat(),
+                _ => SnareConfig::default(),
+            };
+            self.stage.set_snare_config(config);
+        }
+        
+        #[wasm_bindgen]
+        pub fn load_hihat_preset(&mut self, preset_name: &str) {
+            let config = match preset_name {
+                "closed_default" => HiHatConfig::closed_default(),
+                "open_default" => HiHatConfig::open_default(),
+                "closed_tight" => HiHatConfig::closed_tight(),
+                "open_bright" => HiHatConfig::open_bright(),
+                "closed_dark" => HiHatConfig::closed_dark(),
+                "open_long" => HiHatConfig::open_long(),
+                _ => HiHatConfig::closed_default(),
+            };
+            self.stage.set_hihat_config(config);
+        }
+        
+        #[wasm_bindgen]
+        pub fn load_tom_preset(&mut self, preset_name: &str) {
+            let config = match preset_name {
+                "high_tom" => TomConfig::high_tom(),
+                "mid_tom" => TomConfig::mid_tom(),
+                "low_tom" => TomConfig::low_tom(),
+                "floor_tom" => TomConfig::floor_tom(),
+                _ => TomConfig::default(),
+            };
+            self.stage.set_tom_config(config);
+        }
     }
 
     #[wasm_bindgen]

--- a/lib/src/stage.rs
+++ b/lib/src/stage.rs
@@ -45,11 +45,11 @@ impl Stage {
         // Update sequencer and trigger instruments if needed
         if self.sequencer.is_playing {
             self.sequencer.update(current_time);
-            
+
             // Check if we should trigger instruments on the current step
             if self.sequencer.should_trigger_step(current_time) {
                 let current_step = self.sequencer.current_step;
-                
+
                 // Collect which instruments should be triggered to avoid borrow conflicts
                 let mut instruments_to_trigger = Vec::new();
                 for (instrument_index, pattern) in self.sequencer.patterns.iter().enumerate() {
@@ -57,18 +57,18 @@ impl Stage {
                         instruments_to_trigger.push(instrument_index);
                     }
                 }
-                
+
                 // Now trigger the instruments (with mutable access)
                 for instrument_index in instruments_to_trigger {
                     self.trigger_instrument(instrument_index, current_time);
                 }
-                
+
                 // Mark that we've processed this step
                 self.sequencer.last_step_time = current_time;
                 self.sequencer.advance_step();
             }
         }
-        
+
         let mut output = 0.0;
         for instrument in &mut self.instruments {
             output += instrument.tick(current_time);
@@ -188,52 +188,52 @@ impl Stage {
     }
 
     // Sequencer control methods
-    
+
     /// Start the sequencer
     pub fn sequencer_play(&mut self) {
         self.sequencer.play();
     }
-    
+
     /// Stop the sequencer
     pub fn sequencer_stop(&mut self) {
         self.sequencer.stop();
     }
-    
+
     /// Reset the sequencer to step 0
     pub fn sequencer_reset(&mut self) {
         self.sequencer.reset();
     }
-    
+
     /// Clear all patterns
     pub fn sequencer_clear_all(&mut self) {
         self.sequencer.clear_all();
     }
-    
+
     /// Set a step for a specific instrument
     pub fn sequencer_set_step(&mut self, instrument: usize, step: usize, enabled: bool) {
         self.sequencer.set_step(instrument, step, enabled);
     }
-    
+
     /// Get a step for a specific instrument
     pub fn sequencer_get_step(&self, instrument: usize, step: usize) -> bool {
         self.sequencer.get_step(instrument, step)
     }
-    
+
     /// Set the BPM
     pub fn sequencer_set_bpm(&mut self, bpm: f32) {
         self.sequencer.set_bpm(bpm);
     }
-    
+
     /// Get the current BPM
     pub fn sequencer_get_bpm(&self) -> f32 {
         self.sequencer.bpm
     }
-    
+
     /// Get the current step (0-15)
     pub fn sequencer_get_current_step(&self) -> usize {
         self.sequencer.current_step
     }
-    
+
     /// Check if the sequencer is playing
     pub fn sequencer_is_playing(&self) -> bool {
         self.sequencer.is_playing
@@ -251,30 +251,30 @@ impl Sequencer {
             step_interval: 60.0 / (120.0 * 4.0), // 16th notes at 120 BPM
         }
     }
-    
+
     pub fn play(&mut self) {
         self.is_playing = true;
     }
-    
+
     pub fn stop(&mut self) {
         self.is_playing = false;
     }
-    
+
     pub fn reset(&mut self) {
         self.current_step = 0;
         self.last_step_time = 0.0;
     }
-    
+
     pub fn clear_all(&mut self) {
         self.patterns = [[false; 16]; 4];
     }
-    
+
     pub fn set_step(&mut self, instrument: usize, step: usize, enabled: bool) {
         if instrument < 4 && step < 16 {
             self.patterns[instrument][step] = enabled;
         }
     }
-    
+
     pub fn get_step(&self, instrument: usize, step: usize) -> bool {
         if instrument < 4 && step < 16 {
             self.patterns[instrument][step]
@@ -282,24 +282,24 @@ impl Sequencer {
             false
         }
     }
-    
+
     pub fn set_bpm(&mut self, bpm: f32) {
         // Clamp BPM to reasonable range
         self.bpm = bpm.max(60.0).min(180.0);
         // Recalculate step interval (16th notes)
         self.step_interval = 60.0 / (self.bpm * 4.0);
     }
-    
+
     pub fn update(&mut self, current_time: f32) {
         // This method is called from tick() to update internal state
         // The actual triggering logic is handled in tick()
     }
-    
+
     pub fn should_trigger_step(&self, current_time: f32) -> bool {
         // Check if enough time has passed for the next step
         current_time - self.last_step_time >= self.step_interval
     }
-    
+
     pub fn advance_step(&mut self) {
         self.current_step = (self.current_step + 1) % 16;
     }

--- a/lib/src/stage.rs
+++ b/lib/src/stage.rs
@@ -50,11 +50,17 @@ impl Stage {
             if self.sequencer.should_trigger_step(current_time) {
                 let current_step = self.sequencer.current_step;
                 
-                // Trigger instruments that have a hit on the current step
+                // Collect which instruments should be triggered to avoid borrow conflicts
+                let mut instruments_to_trigger = Vec::new();
                 for (instrument_index, pattern) in self.sequencer.patterns.iter().enumerate() {
                     if pattern[current_step] && instrument_index < self.instruments.len() {
-                        self.trigger_instrument(instrument_index, current_time);
+                        instruments_to_trigger.push(instrument_index);
                     }
+                }
+                
+                // Now trigger the instruments (with mutable access)
+                for instrument_index in instruments_to_trigger {
+                    self.trigger_instrument(instrument_index, current_time);
                 }
                 
                 // Mark that we've processed this step

--- a/lib/src/stage.rs
+++ b/lib/src/stage.rs
@@ -84,18 +84,8 @@ impl Stage {
                     self.tom.trigger(current_time);
                 }
 
-                // Also trigger legacy instruments for backward compatibility
-                let mut instruments_to_trigger = Vec::new();
-                for (instrument_index, pattern) in self.sequencer.patterns.iter().enumerate() {
-                    if pattern[current_step] && instrument_index < self.instruments.len() {
-                        instruments_to_trigger.push(instrument_index);
-                    }
-                }
-
-                // Now trigger the legacy instruments (with mutable access)
-                for instrument_index in instruments_to_trigger {
-                    self.trigger_instrument(instrument_index, current_time);
-                }
+                // Basic oscillators are NOT triggered by the sequencer
+                // They should only be triggered manually via "Trigger all instruments" button
 
                 // Mark that we've processed this step
                 self.sequencer.last_step_time = current_time;
@@ -234,11 +224,8 @@ impl Stage {
 
     /// Start the sequencer
     pub fn sequencer_play(&mut self) {
-        // For immediate play, we need to initialize timing
-        // This is a workaround since we don't have current_time here
-        // The real fix is to always use sequencer_play_at_time
-        self.sequencer.play();
-        self.sequencer.last_step_time = 0.0; // Reset timing
+        // Initialize with proper timing - use a small offset to ensure proper initialization
+        self.sequencer.play_at_time(0.001);
     }
     
     /// Start the sequencer with a specific time


### PR DESCRIPTION
Implements a 16-step drum sequencer with 120bpm timing and responsive UI as requested in issue #20.

## Features
- 120bpm clock/timing system (adjustable 60-180 BPM)
- 16-step pattern grid for each of 4 drum instruments
- Transport controls (play/stop/reset/clear)
- Real-time current step indicator with visual feedback
- Live pattern editing while playing
- Stage component owns clock and triggers instruments
- Each instrument holds state for step hits
- Positioned below spectrum analyzer with responsive design

## Implementation
- Rust: Added Sequencer struct and timing logic to Stage
- WASM: Added JavaScript bindings for sequencer control
- UI: Added responsive sequencer component with overflow handling

Closes #20

🤖 Generated with [Claude Code](https://claude.ai/code)