### PR TITLE
feat: Add mixer widget for instrument volume control

### DIFF
--- a/debug-ui/app/globals.css
+++ b/debug-ui/app/globals.css
@@ -24,3 +24,47 @@ body {
   color: var(--foreground);
   font-family: Arial, Helvetica, sans-serif;
 }
+
+/* Mixer slider styles */
+.slider-vertical {
+  appearance: none;
+  -webkit-appearance: none;
+  background: transparent;
+  cursor: pointer;
+}
+
+.slider-vertical::-webkit-slider-track {
+  background: #374151;
+  border-radius: 4px;
+}
+
+.slider-vertical::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  appearance: none;
+  background: #ffffff;
+  border-radius: 50%;
+  width: 12px;
+  height: 12px;
+  border: 2px solid #6b7280;
+  cursor: pointer;
+}
+
+.slider-vertical::-webkit-slider-thumb:hover {
+  background: #f3f4f6;
+  border-color: #4b5563;
+}
+
+.slider-vertical::-moz-range-track {
+  background: #374151;
+  border-radius: 4px;
+  height: 4px;
+}
+
+.slider-vertical::-moz-range-thumb {
+  background: #ffffff;
+  border-radius: 50%;
+  width: 12px;
+  height: 12px;
+  border: 2px solid #6b7280;
+  cursor: pointer;
+}

--- a/debug-ui/app/mixer.tsx
+++ b/debug-ui/app/mixer.tsx
@@ -1,0 +1,150 @@
+'use client';
+
+import React from 'react';
+
+interface MixerProps {
+  kickVolume: number;
+  snareVolume: number;
+  hihatVolume: number;
+  tomVolume: number;
+  onKickVolumeChange: (volume: number) => void;
+  onSnareVolumeChange: (volume: number) => void;
+  onHihatVolumeChange: (volume: number) => void;
+  onTomVolumeChange: (volume: number) => void;
+  isLoaded?: boolean;
+}
+
+export default function Mixer({
+  kickVolume,
+  snareVolume,
+  hihatVolume,
+  tomVolume,
+  onKickVolumeChange,
+  onSnareVolumeChange,
+  onHihatVolumeChange,
+  onTomVolumeChange,
+  isLoaded = false,
+}: MixerProps) {
+  const instrumentData = [
+    {
+      name: 'Kick',
+      volume: kickVolume,
+      onChange: onKickVolumeChange,
+      color: 'bg-red-600',
+      colorHover: 'hover:bg-red-700',
+    },
+    {
+      name: 'Snare',
+      volume: snareVolume,
+      onChange: onSnareVolumeChange,
+      color: 'bg-blue-600',
+      colorHover: 'hover:bg-blue-700',
+    },
+    {
+      name: 'Hi-hat',
+      volume: hihatVolume,
+      onChange: onHihatVolumeChange,
+      color: 'bg-yellow-600',
+      colorHover: 'hover:bg-yellow-700',
+    },
+    {
+      name: 'Tom',
+      volume: tomVolume,
+      onChange: onTomVolumeChange,
+      color: 'bg-purple-600',
+      colorHover: 'hover:bg-purple-700',
+    },
+  ];
+
+  const handleVolumeChange = (instrument: typeof instrumentData[0], value: number) => {
+    instrument.onChange(value);
+  };
+
+  const handleReset = () => {
+    // Reset to default values with headroom (0.6 = -4.4dB)
+    onKickVolumeChange(0.6);
+    onSnareVolumeChange(0.6);
+    onHihatVolumeChange(0.6);
+    onTomVolumeChange(0.6);
+  };
+
+  if (!isLoaded) {
+    return (
+      <div className="mixer-container bg-gray-800 p-4 rounded-lg border border-gray-600">
+        <h3 className="text-lg font-semibold text-white mb-3">Mixer</h3>
+        <div className="text-gray-400">WASM not loaded</div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="mixer-container bg-gray-800 p-4 rounded-lg border border-gray-600">
+      <div className="flex items-center justify-between mb-4">
+        <h3 className="text-lg font-semibold text-white">Mixer</h3>
+        <button
+          onClick={handleReset}
+          className="px-3 py-1 bg-gray-600 hover:bg-gray-700 text-white rounded text-sm font-medium transition-colors"
+        >
+          Reset
+        </button>
+      </div>
+
+      <div className="grid grid-cols-4 gap-4">
+        {instrumentData.map((instrument) => (
+          <div key={instrument.name} className="flex flex-col items-center">
+            {/* Volume Slider */}
+            <div className="flex flex-col items-center h-32 mb-2">
+              <input
+                type="range"
+                min="0"
+                max="1"
+                step="0.01"
+                value={instrument.volume}
+                onChange={(e) => handleVolumeChange(instrument, parseFloat(e.target.value))}
+                className="h-24 w-4 bg-gray-700 rounded-lg appearance-none cursor-pointer slider-vertical"
+                style={{
+                  writingMode: 'vertical-lr',
+                  direction: 'rtl',
+                }}
+              />
+              <div className="mt-2 text-xs text-gray-400 font-mono">
+                {Math.round(instrument.volume * 100)}%
+              </div>
+            </div>
+
+            {/* Volume Level Indicator */}
+            <div className="w-8 h-2 bg-gray-700 rounded-full mb-2 overflow-hidden">
+              <div
+                className={`h-full transition-all duration-150 ${
+                  instrument.volume > 0.8 ? 'bg-red-500' : 
+                  instrument.volume > 0.6 ? 'bg-yellow-500' : 
+                  'bg-green-500'
+                }`}
+                style={{ width: `${instrument.volume * 100}%` }}
+              />
+            </div>
+
+            {/* Instrument Label */}
+            <div className={`px-2 py-1 rounded text-xs font-medium text-white ${instrument.color}`}>
+              {instrument.name}
+            </div>
+          </div>
+        ))}
+      </div>
+
+      <div className="mt-4 text-xs text-gray-400">
+        <div className="flex justify-between items-center">
+          <span>Default values set to 60% for headroom</span>
+          <div className="flex items-center space-x-2">
+            <span className="inline-block w-2 h-2 bg-green-500 rounded-full"></span>
+            <span>Safe</span>
+            <span className="inline-block w-2 h-2 bg-yellow-500 rounded-full"></span>
+            <span>Loud</span>
+            <span className="inline-block w-2 h-2 bg-red-500 rounded-full"></span>
+            <span>Hot</span>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/debug-ui/app/wasm-test.tsx
+++ b/debug-ui/app/wasm-test.tsx
@@ -10,6 +10,7 @@ import init, {
 } from "../public/wasm/oscillator.js";
 
 import Sequencer from "./sequencer";
+import Mixer from "./mixer";
 import { SpectrumAnalyzerWithRef } from "./spectrum-analyzer";
 import { SpectrogramDisplayWithRef } from "./spectrogram-display";
 
@@ -65,7 +66,7 @@ export default function WasmTest() {
     click: 0.3,
     decay: 0.8,
     pitchDrop: 0.6,
-    volume: 0.8,
+    volume: 0.6,
   });
 
   // Hi-hat specific state
@@ -76,7 +77,7 @@ export default function WasmTest() {
     brightness: 0.6,
     decayTime: 0.1,
     attackTime: 0.001,
-    volume: 0.8,
+    volume: 0.6,
     isOpen: false,
   });
 
@@ -89,7 +90,7 @@ export default function WasmTest() {
     crack: 0.5,
     decay: 0.15,
     pitchDrop: 0.3,
-    volume: 0.8,
+    volume: 0.6,
   });
 
   // Tom specific state
@@ -100,7 +101,7 @@ export default function WasmTest() {
     punch: 0.4,
     decay: 0.4,
     pitchDrop: 0.3,
-    volume: 0.8,
+    volume: 0.6,
   });
 
   // Keyboard mapping state
@@ -692,7 +693,7 @@ export default function WasmTest() {
           click: 0.5,
           decay: 0.4,
           pitchDrop: 0.8,
-          volume: 0.8,
+          volume: 0.6,
         });
         break;
       default: // default
@@ -703,7 +704,7 @@ export default function WasmTest() {
           click: 0.3,
           decay: 0.8,
           pitchDrop: 0.6,
-          volume: 0.8,
+          volume: 0.6,
         });
     }
   }
@@ -809,7 +810,7 @@ export default function WasmTest() {
           brightness: 0.6,
           decayTime: 0.1,
           attackTime: 0.001,
-          volume: 0.8,
+          volume: 0.6,
           isOpen: false,
         });
         break;
@@ -842,7 +843,7 @@ export default function WasmTest() {
           brightness: 1.0,
           decayTime: 1.2,
           attackTime: 0.001,
-          volume: 0.8,
+          volume: 0.6,
           isOpen: true,
         });
         break;
@@ -875,7 +876,7 @@ export default function WasmTest() {
           brightness: 0.6,
           decayTime: 0.1,
           attackTime: 0.001,
-          volume: 0.8,
+          volume: 0.6,
           isOpen: false,
         });
     }
@@ -1087,7 +1088,7 @@ export default function WasmTest() {
           crack: 0.8,
           decay: 0.08,
           pitchDrop: 0.5,
-          volume: 0.8,
+          volume: 0.6,
         });
         break;
       case "fat":
@@ -1109,7 +1110,7 @@ export default function WasmTest() {
           crack: 0.5,
           decay: 0.15,
           pitchDrop: 0.3,
-          volume: 0.8,
+          volume: 0.6,
         });
     }
   }
@@ -1254,7 +1255,7 @@ export default function WasmTest() {
           punch: 0.4,
           decay: 0.4,
           pitchDrop: 0.3,
-          volume: 0.8,
+          volume: 0.6,
         });
         break;
       case "low_tom":
@@ -1284,7 +1285,7 @@ export default function WasmTest() {
           punch: 0.4,
           decay: 0.4,
           pitchDrop: 0.3,
-          volume: 0.8,
+          volume: 0.6,
         });
     }
   }
@@ -2651,6 +2652,19 @@ export default function WasmTest() {
 
           {/* Sequencer */}
           <Sequencer stage={stageRef.current} isPlaying={isPlaying} />
+
+          {/* Mixer */}
+          <Mixer
+            kickVolume={kickConfig.volume}
+            snareVolume={snareConfig.volume}
+            hihatVolume={hihatConfig.volume}
+            tomVolume={tomConfig.volume}
+            onKickVolumeChange={(volume) => handleKickConfigChange('volume', volume)}
+            onSnareVolumeChange={(volume) => handleSnareConfigChange('volume', volume)}
+            onHihatVolumeChange={(volume) => handleHihatConfigChange('volume', volume)}
+            onTomVolumeChange={(volume) => handleTomConfigChange('volume', volume)}
+            isLoaded={isLoaded}
+          />
 
           {/* Spectrogram Display */}
           <div>


### PR DESCRIPTION
Adds a new mixer widget to control the relative volume of four instruments with proper headroom for brick wall limiter testing.

## Changes
- Create new Mixer component with vertical sliders
- Set default volumes to 60% for headroom
- Add visual level indicators with color coding
- Include reset button for safe defaults
- Support real-time volume adjustments

Closes #56

Generated with [Claude Code](https://claude.ai/code)