### PR TITLE
fix: kick drum FM snap honors volume setting

### DIFF
--- a/lib/src/kick.rs
+++ b/lib/src/kick.rs
@@ -211,7 +211,7 @@ impl KickDrum {
         // Add FM snap for beater sound
         let fm_snap_output = self.fm_snap.tick(current_time);
 
-        let total_output = sub_output + punch_output + filtered_click_output + fm_snap_output;
+        let total_output = sub_output + punch_output + filtered_click_output + (fm_snap_output * self.config.volume);
 
         // Check if kick is still active
         if !self.sub_oscillator.envelope.is_active


### PR DESCRIPTION
Fixes #62 - kick drum still produces sound at volume 0

The kick drum's FM snap synthesizer was not respecting the volume setting, causing sound to be produced even when volume was set to 0. This fix ensures the FM snap output is multiplied by the kick drum's volume before being added to the total output.

Generated with [Claude Code](https://claude.ai/code)